### PR TITLE
updated WriteTank gizmo file

### DIFF
--- a/gizmos/WriteTank.gizmo
+++ b/gizmos/WriteTank.gizmo
@@ -430,6 +430,7 @@ Gizmo {
   name Write1
   xpos 195
   ypos -34
+  disable {{parent.disable}}
  }
 set N11879e50 [stack 0]
  Output {


### PR DESCRIPTION
- disabling the parent gizmo now also disables in the internal Write1
node