### PR TITLE
SG-11834 fixes a bug with updating the writenode paths (#33)

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,12 +69,17 @@ class NukeWriteNode(tank.platform.Application):
         :param old_context: The sgtk.context.Context being switched from.
         :param new_context: The sgtk.context.Context being switched to.
         """
-        for node in self.get_write_nodes():
-            self.reset_node_render_path(node)
 
         self.__write_node_handler.populate_profiles_from_settings()
         self.__write_node_handler.populate_script_template()
         self.__add_write_node_commands(new_context)
+
+        # now the writenode handler settings have been updated we can update the paths of all existing SG writenodes
+        for node in self.get_write_nodes():
+            # Although there are nuke callbacks to handle setting up the new node; on automatic context change
+            # these are triggered before the engine changes context, so we must manually call it here.
+            # this will force the path to reset and the profiles to be rebuilt.
+            self.__write_node_handler.setup_new_node(node)
         
     def process_placeholder_nodes(self):
         """

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -204,7 +204,7 @@ class TankWriteNodeHandler(object):
         """
         Reset the render path of the specified node.  This
         will force the render path to be updated based on
-        the current script path and configuraton
+        the current script path and configuration.
         """
         is_proxy = node.proxy()
         self.__update_render_path(node, force_reset=True, is_proxy=is_proxy)     
@@ -356,7 +356,7 @@ class TankWriteNodeHandler(object):
 
         # set up all existing nodes:
         for n in self.get_nodes():
-            self.__setup_new_node(n)
+            self.setup_new_node(n)
         
     def remove_callbacks(self):
         """
@@ -596,7 +596,7 @@ class TankWriteNodeHandler(object):
         # alone from now on, unless we someday have a better understanding of
         # what's going on and the consequences of changing the on_node_created
         # behavior.
-        self.__setup_new_node(nuke.thisNode())
+        self.setup_new_node(nuke.thisNode())
 
     def on_compute_path_gizmo_callback(self):
         """
@@ -1404,7 +1404,7 @@ class TankWriteNodeHandler(object):
                     # compute the render path:
                     render_path = self.__compute_render_path_from(node, render_template, width, height, output_name)
                     
-            except TkComputePathError, e:
+            except TkComputePathError as e:
                 # update cache:
                 self.__node_computed_path_settings_cache[(node, is_proxy)] = (cache_entry, str(e), "")
                 
@@ -1780,8 +1780,8 @@ class TankWriteNodeHandler(object):
                             break
                         
         return path_is_locked     
-                
-    def __setup_new_node(self, node):
+
+    def setup_new_node(self, node):
         """
         Setup a node when it's created (either directly or as a result of loading a script).
         This allows us to dynamically populate the profile list.
@@ -2050,7 +2050,7 @@ class TankWriteNodeHandler(object):
             return
         
         # setup the new node:
-        self.__setup_new_node(node)
+        self.setup_new_node(node)
         
         # populate the initial output name based on the render template:
         render_template = self.get_render_template(node)


### PR DESCRIPTION
Bug fix so that when the context changes due to automatic context switching, it now correctly updates the path and the profiles on the SG writenodes in the newly opened scene.